### PR TITLE
Remove distill of arrays with length one.

### DIFF
--- a/geojson-google-maps.js
+++ b/geojson-google-maps.js
@@ -254,12 +254,6 @@
 
   google.maps.geojson.to = function(overlays){
     
-    // If an array of overlays was given and it's
-    // length is 1 then distill to just the overlay
-    if(_isArray(overlays) && overlays.length === 1){
-      overlays = overlays[0];
-    }
-    
     // Array of overlays
     if(_isArray(overlays)){
       


### PR DESCRIPTION
A MultiPoint, a MultiLineString and a MultiPolygon can also be of length one and should not get distilled to a point, line string or polygon.
